### PR TITLE
Add prerequisite in README

### DIFF
--- a/README.md~
+++ b/README.md~
@@ -17,17 +17,11 @@ Test with python3.
 
 DATE=2015-11-05T17:31:27.977;ERR=NO;FRAME=01-03-50-00-00-04-55-09;SLAVE=1;
 
-## Prerequisite 
+## Use it
 
-E.g. in Debian based dists, install package:
-
-sudo apt-get install python3-setuptools
-
-## Setup
+Setup
 
     $ sudo python3 setup.py install
-
-## Use it
 
 Help
 


### PR DESCRIPTION
Hi,

Nice repo you have added! :) When I tried to install it I realized that I first needed to install the package python3-setuptools. I thought it would be great to add this information. I also made some other minor changes. What do you think?

Thanks,

Mikael